### PR TITLE
Fix seperator not found error when syncing blocks

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from log_utils import setup_logging
 
 # Setup structured logging
 logger = setup_logging(
-    level="ERROR",
+    level="INFO",
     log_file="qbtc.log",
     enable_console=True,
     enable_structured=True


### PR DESCRIPTION
Implement chunked protocol for block synchronization to handle responses   exceeding asyncio buffer limits. 

 1. Client side (dht.py): When pulling blocks, it first reads a header to check if the response is chunked. If so, it reads
  chunks sequentially and assembles them.
  2. Server side (gossip.py): When sending blocks, it checks if the response exceeds 50MB. If so, it splits the blocks into chunks
   of 10 blocks each and sends them with a header indicating the total number of chunks.                             